### PR TITLE
Add interface for Airborne module

### DIFF
--- a/penelope_aerospace_pl_msgs/CMakeLists.txt
+++ b/penelope_aerospace_pl_msgs/CMakeLists.txt
@@ -8,33 +8,32 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(shape_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(shape_msgs REQUIRED)
 find_package(trajectory_msgs)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/ModuleState.msg"
-  "msg/ResultCodes.msg"
-  "msg/SolidPrimitiveStamped.msg"
-  "msg/InductionWeldingState.msg"
-  "msg/InfraredThermographyState.msg"
-  "msg/DvmState.msg"
+  "action/CobotDrill.action"
+  "action/DvmInspect.action"
+  "action/InductionWeld.action"
+  "action/InfraredThermographyInspect.action"
+  "action/StringerPlace.action"
   "msg/CobotDrillingHole.msg"
   "msg/CobotDrillingHoleArray.msg"
   "msg/CobotDrillingHoleState.msg"
   "msg/CobotDrillingState.msg"
+  "msg/DvmState.msg"
+  "msg/InductionWeldingState.msg"
+  "msg/InfraredThermographyState.msg"
+  "msg/ModuleState.msg"
+  "msg/ResultCodes.msg"
+  "msg/SolidPrimitiveStamped.msg"
   "msg/StringerPlaceState.msg"
-  "action/InductionWeld.action"
-  "action/InfraredThermographyInspect.action"
-  "action/DvmInspect.action"
-  "action/CobotDrill.action"
-  "action/StringerPlace.action"
-
 
   DEPENDENCIES # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
     geometry_msgs
-    shape_msgs
     sensor_msgs
+    shape_msgs
     trajectory_msgs
 )
 

--- a/penelope_aerospace_pl_msgs/CMakeLists.txt
+++ b/penelope_aerospace_pl_msgs/CMakeLists.txt
@@ -23,10 +23,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CobotDrillingHoleArray.msg"
   "msg/CobotDrillingHoleState.msg"
   "msg/CobotDrillingState.msg"
+  "msg/StringerPlaceState.msg"
   "action/InductionWeld.action"
   "action/InfraredThermographyInspect.action"
   "action/DvmInspect.action"
   "action/CobotDrill.action"
+  "action/StringerPlace.action"
+
 
   DEPENDENCIES # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
     geometry_msgs

--- a/penelope_aerospace_pl_msgs/action/StringerPlace.action
+++ b/penelope_aerospace_pl_msgs/action/StringerPlace.action
@@ -1,0 +1,52 @@
+#-------------------------------------------------------------------------------
+# Accurate stringer placement
+#-------------------------------------------------------------------------------
+
+
+#-------------------------------------------------------------------------------
+# Description:
+#   The purpose of this action definition is to perform the closed loop 
+#   placement of the stringer onto the skin (performed by Airborne).
+#   IR driving software is set up to execute the same exact measurment 4 times. 
+#   Can halt if scenario of vibration exceeding 2mm appears. Measurement is
+#   repeatable. Each measurement should last no longer than 10 minutes. If a
+#   measurement must be broken off/halted, nothing is lost. The measurement can 
+#   simply be restarted, after a pre-defined cooling down period
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Action goal fields
+#-------------------------------------------------------------------------------
+bool start_accurate_placement               # Execute closed loop placement of the stringer
+
+---
+
+#-------------------------------------------------------------------------------
+# Action result fields
+#-------------------------------------------------------------------------------
+# coordinates for the final gantry position after correcting the errors
+# float[] final_position
+geometry_msgs/Pose final_position
+
+# Number of iterations to get placement within tolerance
+uint16 attempts
+
+
+# Action success/failure indicator.
+# Refer to penelope_aerospace_pl_msgs/msg/ResultCodes for defined error codes. 
+uint16 result_code
+
+# Status message (empty if action succeeded)
+string message
+
+---
+
+#-------------------------------------------------------------------------------
+# Action feedback fields
+#-------------------------------------------------------------------------------
+
+# Module specific state
+AccurateStringerPlacementState process_state
+
+# Generic module state
+ModuleState module_state

--- a/penelope_aerospace_pl_msgs/action/StringerPlace.action
+++ b/penelope_aerospace_pl_msgs/action/StringerPlace.action
@@ -54,7 +54,7 @@ string message
 #-------------------------------------------------------------------------------
 
 # Module specific state
-AccurateStringerPlacementState process_state
+StringerPlaceState process_state
 
 # Generic module state
 ModuleState module_state

--- a/penelope_aerospace_pl_msgs/action/StringerPlace.action
+++ b/penelope_aerospace_pl_msgs/action/StringerPlace.action
@@ -7,17 +7,19 @@
 # Description:
 #   The purpose of this action definition is to perform the closed loop 
 #   placement of the stringer onto the skin (performed by Airborne).
-#   IR driving software is set up to execute the same exact measurment 4 times. 
-#   Can halt if scenario of vibration exceeding 2mm appears. Measurement is
-#   repeatable. Each measurement should last no longer than 10 minutes. If a
-#   measurement must be broken off/halted, nothing is lost. The measurement can 
-#   simply be restarted, after a pre-defined cooling down period
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
 # Action goal fields
 #-------------------------------------------------------------------------------
-bool start_accurate_placement               # Execute closed loop placement of the stringer
+
+# One PoseArray per stringer placement. The path consists of the setpoints to 
+# reach.
+geometry_msgs/PoseArray[] paths
+
+# Indicate if the poses in the array have the end-effector close enough to the
+# final position such that the sensors are within their measurement range.
+bool[] sensors_in_range
 
 ---
 
@@ -25,12 +27,18 @@ bool start_accurate_placement               # Execute closed loop placement of t
 # Action result fields
 #-------------------------------------------------------------------------------
 # coordinates for the final gantry position after correcting the errors
-# float[] final_position
-geometry_msgs/Pose final_position
+geometry_msgs/PoseStamped final_stringer_pose
+
+# Estimated skin position resulting from the stringer placements. Every place
+# operation generates a separate estimate
+geometry_msgs/PoseStamped skin_pose_estimate
 
 # Number of iterations to get placement within tolerance
-uint16 attempts
+uint16[] attempts
 
+# Placement result per stringer, corresponding to the stringer IDS in 
+# final_stringer_pose
+bool[] stringer_placement_pass
 
 # Action success/failure indicator.
 # Refer to penelope_aerospace_pl_msgs/msg/ResultCodes for defined error codes. 

--- a/penelope_aerospace_pl_msgs/msg/StringerPlaceState.msg
+++ b/penelope_aerospace_pl_msgs/msg/StringerPlaceState.msg
@@ -1,0 +1,14 @@
+#-------------------------------------------------------------------------------
+# PLACEHOLDER StringerPlaceState (Airborne)
+#-------------------------------------------------------------------------------
+
+# Description of the module states:
+#  STATE_1
+#    ...
+#  STATE_2
+#    ...
+
+# uint8 STATE_1=1
+# uint8 STATE_2=2
+
+uint16 data


### PR DESCRIPTION
Add the ROS2 action interface for the Airborne module.

## Motivation and Context

The action from Airborne is the last action to be added to the interface for the PeneloPe pilot line. 

## Changes

- Add message definitions needed for the Airborne module action
  - Add the `StringerPlace.action` action definition
  - Add a placeholder for the `StringerPlaceState.msg` definition

## Type of changes

- New feature (non-breaking change which adds functionality)

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [X] Update dependencies
- [ ] Update version
