### PR TITLE
[TNO] Add missing inputs to goal and images to result body

### DIFF
--- a/penelope_aerospace_pl_msgs/action/DvmInspect.action
+++ b/penelope_aerospace_pl_msgs/action/DvmInspect.action
@@ -14,6 +14,10 @@ SolidPrimitiveStamped allocated_space
 # Define the location of the geometry file
 string geometry_file_location # e.g. a '.ply' file
 
+# TODO: Add description
+string[] dvm_aquisition_parameters_directories
+string[] dvm_aquisition_parameters_files
+
 # Define process parameters
 #   The robot settings
 string[] robot_parameters # e.g. 'robot.ini'

--- a/penelope_aerospace_pl_msgs/action/DvmInspect.action
+++ b/penelope_aerospace_pl_msgs/action/DvmInspect.action
@@ -39,6 +39,8 @@ DvmState[] measurement_state
 bool[] measurement_ready
 bool[] processed_data_available
 bool[] ndt_approved
+sensor_msgs/Image[] intensity_map
+sensor_msgs/Image[] processed_scan
 
 # Action success/failure indicator.
 # Refer to penelope_aerospace_pl_msgs/msg/ResultCodes for defined error codes.

--- a/penelope_aerospace_pl_msgs/msg/DvmState.msg
+++ b/penelope_aerospace_pl_msgs/msg/DvmState.msg
@@ -37,5 +37,10 @@ uint8 CANCELLED = 8
 uint8 ABORTED = 9
 uint8 FAILED = 10
 uint8 OFFLINE = 11
+uint8 NOTHING_HAPPENING = 12
+uint8 MOVING = 13
+uint8 SCAN_FINISHED = 15
+uint8 SCAN_FAILED = 16
+uint8 SCAN_ABORTED = 17
 
 uint8 data


### PR DESCRIPTION
The DVM application requires the folder and filename of config files describing the process and plate on which the scan is performed. Furthermore, the results of the process are processed images and a intensity map. As such this is added to the action goal and result on request of TNO. 