### PR TITLE
Build ExampleAction (for testing purposes)

### DIFF
--- a/penelope_aerospace_pl_msgs/CMakeLists.txt
+++ b/penelope_aerospace_pl_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/AccurateStringerPlacement.action"
   "action/CobotDrill.action"
   "action/DvmInspect.action"
+  "action/ExampleAction.action"
   "action/InductionWeld.action"
   "action/InfraredThermographyInspect.action"
   "msg/CobotDrillingHole.msg"

--- a/penelope_aerospace_pl_msgs/action/ExampleAction.action
+++ b/penelope_aerospace_pl_msgs/action/ExampleAction.action
@@ -6,14 +6,14 @@
 #-------------------------------------------------------------------------------
 # Action goal fields
 #-------------------------------------------------------------------------------
-<GOAL_FIELDS>
+# <GOAL_FIELDS>
 
 ---
 
 #-------------------------------------------------------------------------------
 # Action result fields
 #-------------------------------------------------------------------------------
-<RESULT_FIELDS>
+# <RESULT_FIELDS>
 
 # Action success/failure indicator.
 # Refer to penelope_aerospace_pl_msgs/msg/ResultCodes for defined error codes. 
@@ -22,12 +22,12 @@ uint16 result_code
 # Status message (empty if action succeeded)
 string message
 
---- 
+---
 
 #-------------------------------------------------------------------------------
 # Action feedback fields
 #-------------------------------------------------------------------------------
-<FEEDBACK_FIELDS>
+# <FEEDBACK_FIELDS>
 
 # Generic module state
 ModuleState module_state


### PR DESCRIPTION
Build the `ExampleAction` so it can be used for testing. 

## Motivation & Context
The `ExampleAction` contains the fields that all PeneloPe action interfaces should support. For testing this action therefore is more generic than the other action definitions.

## Changes
- Fixed trailing space in the action definition as this results in a error while building
- Add the action to the `CMakeLists.txt` so it gets build